### PR TITLE
KCL-5612 New tests, rendering algorithm improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the positioning of the highlights inside body on pages with scrollbars by improving the rendering algorithm.
+- Fixed the positioning of the highlights inside table elements by improving the rendering algorithm.
+
 ## [1.2.0] - 2020-10-07
 
 ### Added

--- a/src/utils/node.ts
+++ b/src/utils/node.ts
@@ -1,8 +1,17 @@
 interface IParentMetadata {
-  readonly hasRelativePosition: boolean;
-  readonly hasRestrictedOverflow: boolean;
+  readonly isPositioned: boolean;
+  readonly isContentClipped: boolean;
 }
 
+/**
+ * Iterate through node ancestors and find an element which will be used as a parent for
+ * the highlights container (highlights -> container -> parent). This element should either be
+ * positioned (position is anything except static) or should have its content clipped. In case of
+ * table element (td, th, table) it should be positioned or it will be ignored (even if its content is clipped).
+ *
+ * @param {HTMLElement} node
+ * @returns {[HTMLElement, IParentMetadata] | [null, null]}
+ */
 export function getParentForHighlight(node: HTMLElement): [HTMLElement, IParentMetadata] | [null, null] {
   const parent = node.parentNode;
 
@@ -13,11 +22,21 @@ export function getParentForHighlight(node: HTMLElement): [HTMLElement, IParentM
     const overflow = computedStyle.getPropertyValue('overflow');
 
     const metadata: IParentMetadata = {
-      hasRelativePosition: position === 'relative',
-      hasRestrictedOverflow: overflow.split(' ').some((value) => ['auto', 'scroll', 'clip', 'hidden'].includes(value)),
+      // The positioned element is an element whose computed position is anything except static.
+      // Offset top and offset left values of child element are relative to the first positioned ancestor, so we can use
+      // it to correctly position the highlight.
+      isPositioned: position !== 'static',
+      // Content is clipped when overflow of the element is hidden (auto, scroll, clip, hidden). Highlights should be placed
+      // inside such elements so that they do not overflow their parent.
+      isContentClipped: overflow.split(' ').some((value) => ['auto', 'scroll', 'clip', 'hidden'].includes(value)),
     };
 
-    return metadata.hasRelativePosition || metadata.hasRestrictedOverflow
+    // Table HTML element (td, th, table) can be an offset parent of some node, but unless it is positioned it will not be
+    // used as a offset parent for the absolute positioned child (highlight). That is why we should ignore those elements and
+    // do not use them as parents unless they are positioned. Otherwise, the highlighting might broke for the tables.
+    const isNotTable = !['TD', 'TH', 'TABLE'].includes(parent.tagName);
+
+    return metadata.isPositioned || (metadata.isContentClipped && isNotTable)
       ? [parent, metadata]
       : getParentForHighlight(parent);
   }
@@ -25,12 +44,24 @@ export function getParentForHighlight(node: HTMLElement): [HTMLElement, IParentM
   return [null, null];
 }
 
-export function getRelativeScrollOffset(node: Element | null): [number, number] {
-  if (!node || !(node instanceof HTMLElement)) {
+/**
+ * Iterate through node ancestors until HTMLElement.offsetParent is reached and sum scroll offsets.
+ *
+ * @param {HTMLElement | null} node
+ * @returns {[number, number]}
+ *  where the first number is a totalScrollTop, and the second number is a totalScrollLeft.
+ */
+export function getTotalScrollOffset(node: HTMLElement | null): [number, number] {
+  if (!node) {
     return [0, 0];
   }
 
   const offsetParent = node.offsetParent;
+
+  // HTMLElement.offsetParent can be null when the node is <body> or <html>
+  if (!offsetParent) {
+    return [0, 0];
+  }
 
   let scrollTop = 0;
   let scrollLeft = 0;

--- a/test-browser/utils/node.spec.ts
+++ b/test-browser/utils/node.spec.ts
@@ -1,16 +1,44 @@
 import { createHtmlFixture } from '../test-helpers/createHtmlFixture';
-import { getParentForHighlight } from '../../src/utils/node';
+import { getParentForHighlight, getTotalScrollOffset } from '../../src/utils/node';
 
 describe('node.ts', () => {
   describe('getParentForHighlight', () => {
     const fixture = createHtmlFixture();
 
-    it('should return the closest parent with relative position', () => {
+    it('should return [null, null] when there is no suitable parent', () => {
+      // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
+      fixture.setHtml(`
+        <div id="a">
+            <div id="c">
+                <div id="b">
+                    <div id="d">
+                        <div id="e">
+                            <div id="target"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <style>
+                body {
+                    overflow: visible !important;
+                    position: static !important;
+                }
+            </style>
+        </div>
+      `);
+      // </editor-fold>
+
+      const target = fixture.querySelector('#target') as HTMLElement;
+      const result = getParentForHighlight(target);
+      expect(result).toEqual([null, null]);
+    });
+
+    it('should return the positioned parent', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
         <div id="a" style="position: relative">
-            <div id="b" style="position: absolute">
-                <div id="c" style="position: relative">
+            <div id="c" style="position: relative">
+                <div id="b" style="position: absolute">
                     <div id="d">
                         <div id="e" style="position: static">
                             <div id="target"></div>
@@ -24,14 +52,14 @@ describe('node.ts', () => {
 
       const target = fixture.querySelector('#target') as HTMLElement;
       const [element, metadata] = getParentForHighlight(target);
-      expect(element?.id).toEqual('c');
+      expect(element?.id).toEqual('b');
       expect(metadata).toEqual({
-        hasRelativePosition: true,
-        hasRestrictedOverflow: false,
+        isPositioned: true,
+        isContentClipped: false,
       });
     });
 
-    it('should return the closest parent with restricted overflow', () => {
+    it('should return the parent with clipped content', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
         <div id="a" style="position: relative">
@@ -52,9 +80,165 @@ describe('node.ts', () => {
       const [element, metadata] = getParentForHighlight(target);
       expect(element?.id).toEqual('c');
       expect(metadata).toEqual({
-        hasRelativePosition: false,
-        hasRestrictedOverflow: true,
+        isPositioned: false,
+        isContentClipped: true,
       });
+    });
+
+    it('should return the closest parent which is positioned or has clipped content', () => {
+      // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
+      fixture.setHtml(`
+        <div id="a" style="position: relative">
+            <div id="b" style="position: static">
+                <div id="c" style="overflow: scroll">
+                    <div id="d">
+                        <div id="e" style="position: static">
+                            <div id="targetA"></div>
+                        </div>
+                    </div>
+                </div>
+                <div id="targetB"></div>
+            </div>
+        </div>
+      `);
+      // </editor-fold>
+
+      const targetA = fixture.querySelector('#targetA') as HTMLElement;
+      const targetB = fixture.querySelector('#targetB') as HTMLElement;
+
+      const resultA = getParentForHighlight(targetA);
+      const resultB = getParentForHighlight(targetB);
+
+      expect(resultA?.[0]?.id).toEqual('c');
+      expect(resultB?.[0]?.id).toEqual('a');
+    });
+
+    it('should ignore table elements when they are not positioned', () => {
+      // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
+      fixture.setHtml(`
+        <div id="a" style="position: relative">
+            <table id="b" style="overflow: hidden">
+                <tbody id="c">
+                    <tr id="d">
+                        <td id="e" style="overflow: hidden; max-width: 10px;">
+                            <div id="target" style="min-height: 100px;"></div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+      `);
+      // </editor-fold>
+
+      const target = fixture.querySelector('#target') as HTMLElement;
+      const [element] = getParentForHighlight(target);
+      expect(element?.id).toEqual('a');
+    });
+
+    it('should acknowledge table elements when they are positioned', () => {
+      // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
+      fixture.setHtml(`
+        <div id="a" style="position: relative">
+            <table id="b" style="overflow: hidden; position: relative;">
+                <tbody id="c">
+                    <tr id="d">
+                        <td id="e" style="overflow: scroll; max-width: 10px;">
+                            <div id="target" style="min-height: 100px;"></div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+      `);
+      // </editor-fold>
+
+      const target = fixture.querySelector('#target') as HTMLElement;
+      const [element] = getParentForHighlight(target);
+      expect(element?.id).toEqual('b');
+    });
+  });
+
+  describe('getTotalScrollOffset', () => {
+    const fixture = createHtmlFixture();
+
+    it('should return [0, 0] when no node provided', () => {
+      expect(getTotalScrollOffset(null)).toEqual([0, 0]);
+    });
+
+    it('should return [0, 0] when element has no offsetParent', () => {
+      expect(getTotalScrollOffset(document.body)).toEqual([0, 0]);
+    });
+
+    it('should return total scroll offset', () => {
+      // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
+      fixture.setHtml(`
+        <div id="container" style="position: relative">
+            <div id="a" style="max-height: 30px; max-width: 30px; overflow: scroll;">
+                <div id="b" style="min-height: 200px; min-width: 200px;">
+                    <div id="c" style="max-height: 80px; max-width: 80px; overflow: scroll;">
+                        <div id="d" style="min-height: 200px; min-width: 200px;">
+                            <div id="target"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+      `);
+      // </editor-fold>
+
+      const divA = fixture.querySelector('#a') as HTMLElement;
+      const divC = fixture.querySelector('#c') as HTMLElement;
+      const target = fixture.querySelector('#target') as HTMLElement;
+
+      divA.scrollTop = 10;
+      divA.scrollLeft = 20;
+
+      divC.scrollTop = 30;
+      divC.scrollLeft = 40;
+
+      const [scrollTop, scrollLeft] = getTotalScrollOffset(target);
+
+      expect(Math.ceil(scrollTop)).toEqual(40);
+      expect(Math.ceil(scrollLeft)).toEqual(60);
+    });
+
+    it('should not include scroll offset of the offsetParent', () => {
+      // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
+      fixture.setHtml(`
+        <div id="container" style="position: relative; max-height: 20px; max-width: 20px; overflow: scroll;">
+            <div id="a" style="min-height: 200px; min-width: 200px;">
+                <div id="b" style="max-height: 30px; max-width: 30px; overflow: scroll;">
+                    <div id="c" style="min-height: 200px; min-width: 200px;">
+                        <div id="d" style="max-height: 80px; max-width: 80px; overflow: scroll;">
+                            <div id="e" style="min-height: 200px; min-width: 200px;">
+                                <div id="target"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+      `);
+      // </editor-fold>
+
+      const offsetParent = fixture.querySelector('#container') as HTMLElement;
+      const divB = fixture.querySelector('#b') as HTMLElement;
+      const divD = fixture.querySelector('#d') as HTMLElement;
+      const target = fixture.querySelector('#target') as HTMLElement;
+
+      offsetParent.scrollTop = 10;
+      offsetParent.scrollLeft = 20;
+
+      divB.scrollTop = 30;
+      divB.scrollLeft = 40;
+
+      divD.scrollTop = 50;
+      divD.scrollLeft = 60;
+
+      const [scrollTop, scrollLeft] = getTotalScrollOffset(target);
+
+      expect(Math.ceil(scrollTop)).toEqual(80);
+      expect(Math.ceil(scrollLeft)).toEqual(100);
     });
   });
 });


### PR DESCRIPTION
- Add comments to the rendering algorithm and its helpers for better code readability.
- Refactor code in the renderer to get rid of unnecessary if blocks.
- Fix `getParentForHighlight` to ignore table elements when they are not positioned.
- Fix `getParentForHighlight` to include all positioned elements (previously included only elements with `position: relative`).
- Rename `getRelativeScrollOffset` to `getTotalScrollOffset`.
- Do not count scroll offset for elements without `offsetParent` (`<body>`, `<html>`).
- Implemented new unit tests.