### PR TITLE
KCL-7004 Make data attributes parser customizable

### DIFF
--- a/src/lib/IFrameCommunicatorTypes.ts
+++ b/src/lib/IFrameCommunicatorTypes.ts
@@ -8,12 +8,49 @@ export interface IElementClickedMessageMetadata {
   readonly elementRect: DOMRect;
 }
 
-export interface IElementClickedMessageData {
+interface IClickedMessageData {
+  readonly projectId: string;
+  readonly languageCodename: string;
+}
+
+export interface IContentItemClickedMessageData extends IClickedMessageData {
+  readonly itemId: string;
+}
+
+export interface IContentComponentClickedMessageData extends IContentItemClickedMessageData {
+  readonly contentComponentId: string;
+}
+
+export interface IElementClickedMessageData extends IContentItemClickedMessageData {
+  readonly contentComponentId?: string;
+  readonly elementCodename: string;
+}
+
+export enum InsertPosition {
+  After = 'after',
+  Before = 'before',
+  End = 'end',
+  Start = 'start',
+}
+
+interface IRelativeInsertPosition {
+  readonly targetId: string;
+  readonly placement: InsertPosition.Before | InsertPosition.After;
+}
+
+interface IFixedInsertPosition {
+  readonly placement: InsertPosition.Start | InsertPosition.End;
+}
+
+export type PlusRequestInsertPosition = IRelativeInsertPosition | IFixedInsertPosition;
+
+export interface IPlusRequestMessageData {
   readonly projectId: string;
   readonly languageCodename: string;
   readonly itemId: string;
-  readonly elementCodename: string;
   readonly contentComponentId?: string;
+  readonly elementCodename: string;
+  readonly insertPosition: PlusRequestInsertPosition;
 }
 
 export interface IPluginStatusMessageData {

--- a/src/lib/NodeSmartLinkProvider.ts
+++ b/src/lib/NodeSmartLinkProvider.ts
@@ -1,4 +1,3 @@
-import { DataAttribute } from '../utils/dataAttributes';
 import { EventManager } from './EventManager';
 import { webComponentTags } from '../web-components/components';
 import { IElementClickedMessageData, IElementClickedMessageMetadata } from './IFrameCommunicatorTypes';
@@ -246,23 +245,18 @@ export class NodeSmartLinkProvider {
   };
 
   private onEditElement = (event: KSLHighlightElementEvent): void => {
-    const attributes = event.detail.dataAttributes;
+    const { data, targetNode } = event.detail;
 
-    if (attributes.has(DataAttribute.ElementCodename)) {
-      const data: Partial<IElementClickedMessageData> = {
-        projectId: attributes.get(DataAttribute.ProjectId),
-        languageCodename: attributes.get(DataAttribute.LanguageCodename),
-        itemId: attributes.get(DataAttribute.ItemId),
-        contentComponentId: attributes.get(DataAttribute.ComponentId),
-        elementCodename: attributes.get(DataAttribute.ElementCodename),
-      };
-
-      const element = event.detail.targetNode;
+    if ('elementCodename' in data && data.elementCodename) {
       const metadata: IElementClickedMessageMetadata = {
-        elementRect: element.getBoundingClientRect(),
+        elementRect: targetNode.getBoundingClientRect(),
       };
 
       this.events.emit(NodeSmartLinkProviderEventType.ElementClicked, data, metadata);
+    } else if ('contentComponentId' in data && data.contentComponentId) {
+      console.warn('Warning: Edit button for content components is not yet supported.');
+    } else if ('itemId' in data && data.itemId) {
+      console.warn('Warning: Edit button for content items is not yet supported.');
     } else {
       console.warn(
         'Warning: Some required attributes are not found or the edit button for this type of element is not yet supported.'

--- a/src/utils/dataAttributes.ts
+++ b/src/utils/dataAttributes.ts
@@ -202,7 +202,7 @@ function parseDataAttributes(
 
       console.log('Value: ', value);
       console.log('Already parsed: ', parsed.has(key));
-      console.log('Data-attribute taken by previous token: ', takenDataAttributes.has(dataAttribute));
+      console.log('Already taken by previous token: ', takenDataAttributes.has(dataAttribute));
 
       if (!value && !parsed.has(key) && !optional) {
         console.log('[Result]: Required data-attribute is missing.');

--- a/src/web-components/KSLHighlightElement.ts
+++ b/src/web-components/KSLHighlightElement.ts
@@ -1,14 +1,14 @@
 import { ButtonType, KSLButtonElement } from './KSLButtonElement';
 import { IconName, KSLIconElement } from './KSLIconElement';
 import { assert } from '../utils/assert';
-import { getDataAttributesFromElementAncestors, getDataAttributesFromEventPath } from '../utils/dataAttributes';
 import { getHighlightTypeForElement, HighlightType } from '../utils/customElements';
 import { ElementPositionOffset, KSLPositionedElement } from './abstract/KSLPositionedElement';
 import { KSLContainerElement } from './KSLContainerElement';
 import { createTemplateForCustomElement } from '../utils/node';
+import { DeepPartial, EditButtonClickedData, parseEditButtonDataAttributes } from '../utils/dataAttributes';
 
 interface IKSLHighlightElementEventData {
-  readonly dataAttributes: ReadonlyMap<string, string>;
+  readonly data: DeepPartial<EditButtonClickedData>;
   readonly targetNode: HTMLElement;
 }
 
@@ -195,7 +195,7 @@ export class KSLHighlightElement extends KSLPositionedElement {
     if (this.targetRef) {
       this.targetRef.addEventListener('mousemove', this.handleTargetNodeMouseEnter);
       this.targetRef.addEventListener('mouseleave', this.handleTargetNodeMouseLeave);
-      this.targetRef.addEventListener('click', this.handleTargetNodeClick);
+      this.targetRef.addEventListener('click', this.handleEditButtonClick);
     }
   };
 
@@ -222,7 +222,7 @@ export class KSLHighlightElement extends KSLPositionedElement {
     if (this.targetRef) {
       this.targetRef.removeEventListener('mousemove', this.handleTargetNodeMouseEnter);
       this.targetRef.removeEventListener('mouseleave', this.handleTargetNodeMouseLeave);
-      this.targetRef.removeEventListener('click', this.handleTargetNodeClick);
+      this.targetRef.removeEventListener('click', this.handleEditButtonClick);
     }
   };
 
@@ -240,26 +240,16 @@ export class KSLHighlightElement extends KSLPositionedElement {
     event.preventDefault();
     event.stopPropagation();
 
-    const dataAttributes = getDataAttributesFromElementAncestors(this.targetRef);
+    const dataAttributes = parseEditButtonDataAttributes(this.targetRef);
     this.dispatchEditEvent(dataAttributes);
   };
 
-  private handleTargetNodeClick = (event: MouseEvent): void => {
-    assert(this.targetRef, 'Target node is not set for this highlight.');
-
-    event.preventDefault();
-    event.stopPropagation();
-
-    const dataAttributes = getDataAttributesFromEventPath(event);
-    this.dispatchEditEvent(dataAttributes);
-  };
-
-  private dispatchEditEvent = (dataAttributes: ReadonlyMap<string, string>): void => {
+  private dispatchEditEvent = (data: DeepPartial<EditButtonClickedData>): void => {
     assert(this.targetRef, 'Target node is not set for this highlight element.');
 
     const customEvent = new CustomEvent<IKSLHighlightElementEventData>('ksl:highlight:edit', {
       detail: {
-        dataAttributes,
+        data,
         targetNode: this.targetRef,
       },
     });

--- a/src/web-components/KSLPlusButtonElement.ts
+++ b/src/web-components/KSLPlusButtonElement.ts
@@ -3,9 +3,9 @@ import { IconName } from './KSLIconElement';
 import { assert } from '../utils/assert';
 import { KSLPopoverElement } from './KSLPopoverElement';
 import { ElementPositionOffset, KSLPositionedElement } from './abstract/KSLPositionedElement';
-import { MetadataAttribute } from '../utils/dataAttributes';
 import { KSLContainerElement } from './KSLContainerElement';
 import { createTemplateForCustomElement } from '../utils/node';
+import { MetadataAttribute, parsePlusButtonDataAttributes } from '../utils/dataAttributes';
 
 const popoverHTML = `
   <style>
@@ -166,10 +166,15 @@ export class KSLPlusButtonElement extends KSLPositionedElement {
       return;
     }
 
+    assert(this.targetRef, 'Target node is not set for this plus button.');
+
     event.preventDefault();
     event.stopPropagation();
 
     this.buttonRef.loading = true;
+
+    const dataAttributes = parsePlusButtonDataAttributes(this.targetRef);
+    console.log({ dataAttributes });
 
     setTimeout(() => {
       this.showPopover();

--- a/test-browser/utils/dataAttributes.spec.ts
+++ b/test-browser/utils/dataAttributes.spec.ts
@@ -9,19 +9,26 @@ describe('dataAttributes.ts', () => {
     it('should parse data attributes for edit element button', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
-        <div data-kontent-project-id="a" data-kontent-language-codename="a">
-           <div data-kontent-item-id="a" data-kontent-component-id="a" data-kontent-element-codename="a"></div>
+        <div 
+          data-kontent-project-id="8ec75bbd-c1b9-4d10-8ac8-a7f985109301" 
+          data-kontent-language-codename="en-us"
+        >
+           <div 
+              data-kontent-item-id="c37b9222-e3a0-46ff-9cda-45948c6ca876" 
+              data-kontent-component-id="46d79723-adc9-4957-9bfb-9d015c11d8f1" 
+              data-kontent-element-codename="sections"
+           />
         </div>
     `);
       // </editor-fold>
 
-      const target = fixture.querySelector('[data-kontent-element-codename="a"]') as HTMLElement;
+      const target = fixture.querySelector('[data-kontent-element-codename]') as HTMLElement;
       const expected = {
-        projectId: 'a',
-        languageCodename: 'a',
-        itemId: 'a',
-        contentComponentId: 'a',
-        elementCodename: 'a',
+        projectId: '8ec75bbd-c1b9-4d10-8ac8-a7f985109301',
+        languageCodename: 'en-us',
+        itemId: 'c37b9222-e3a0-46ff-9cda-45948c6ca876',
+        contentComponentId: '46d79723-adc9-4957-9bfb-9d015c11d8f1',
+        elementCodename: 'sections',
       };
 
       expect(parseEditButtonDataAttributes(target)).toEqual(expected);
@@ -30,20 +37,23 @@ describe('dataAttributes.ts', () => {
     it('should parse data attributes for edit component button', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
-        <div data-kontent-project-id="a" data-kontent-language-codename="a">
-           <div data-kontent-item-id="a">
-              <div data-kontent-component-id="a"></div>
+        <div 
+          data-kontent-project-id="a5a45323-4a00-4258-be3d-5d16b529969a" 
+          data-kontent-language-codename="cs"
+        >
+           <div data-kontent-item-id="ad81ad4f-f574-4460-ba67-1a14164ad987">
+              <div data-kontent-component-id="bfae94f4-638c-4ab2-957a-6f4636475ab9" />
            </div>
         </div>
     `);
       // </editor-fold>
 
-      const target = fixture.querySelector('[data-kontent-component-id="a"]') as HTMLElement;
+      const target = fixture.querySelector('[data-kontent-component-id]') as HTMLElement;
       const expected = {
-        projectId: 'a',
-        languageCodename: 'a',
-        itemId: 'a',
-        contentComponentId: 'a',
+        projectId: 'a5a45323-4a00-4258-be3d-5d16b529969a',
+        languageCodename: 'cs',
+        itemId: 'ad81ad4f-f574-4460-ba67-1a14164ad987',
+        contentComponentId: 'bfae94f4-638c-4ab2-957a-6f4636475ab9',
       };
 
       expect(parseEditButtonDataAttributes(target)).toEqual(expected);
@@ -52,19 +62,19 @@ describe('dataAttributes.ts', () => {
     it('should parse data attributes for edit item button', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
-        <div data-kontent-project-id="a">
-           <div data-kontent-language-codename="a">
-              <div data-kontent-item-id="a"></div>
+        <div data-kontent-project-id="285dd2ad-3a16-428f-820a-84e3eb4de3b3">
+           <div data-kontent-language-codename="nl">
+              <div data-kontent-item-id="4a5e4e01-d8b4-4d06-a0ff-42ac7e1b4f11"/>
            </div>
         </div>
     `);
       // </editor-fold>
 
-      const target = fixture.querySelector('[data-kontent-item-id="a"]') as HTMLElement;
+      const target = fixture.querySelector('[data-kontent-item-id]') as HTMLElement;
       const expected = {
-        projectId: 'a',
-        languageCodename: 'a',
-        itemId: 'a',
+        projectId: '285dd2ad-3a16-428f-820a-84e3eb4de3b3',
+        languageCodename: 'nl',
+        itemId: '4a5e4e01-d8b4-4d06-a0ff-42ac7e1b4f11',
       };
 
       expect(parseEditButtonDataAttributes(target)).toEqual(expected);
@@ -73,13 +83,13 @@ describe('dataAttributes.ts', () => {
     it('should ignore optional attributes out of their scope', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
-        <div data-kontent-project-id="a">
-            <div data-kontent-language-codename="a">
-                <div data-kontent-item-id="a">
-                    <div data-kontent-component-id="a">
-                        <div data-kontent-element-codename="a">
-                            <div data-kontent-item-id="b">
-                                <div data-kontent-element-codename="b"></div>
+        <div data-kontent-project-id="4e870857-9059-4f2a-9079-618200fedff2">
+            <div data-kontent-language-codename="hr">
+                <div data-kontent-item-id="e35acd87-9911-4b0b-be74-521ae9a85421">
+                    <div data-kontent-component-id="3024f2d5-effc-49b1-b4d1-0d732e49d7fc">
+                        <div data-kontent-element-codename="sections">
+                            <div data-kontent-item-id="345fb42f-e243-4de0-83cd-a109799d0973">
+                                <div data-kontent-element-codename="comments"></div>
                             </div>
                         </div>
                     </div>
@@ -89,12 +99,12 @@ describe('dataAttributes.ts', () => {
     `);
       // </editor-fold>
 
-      const target = fixture.querySelector('[data-kontent-element-codename="b"]') as HTMLElement;
+      const target = fixture.querySelector('[data-kontent-element-codename="comments"]') as HTMLElement;
       const expected = {
-        projectId: 'a',
-        languageCodename: 'a',
-        itemId: 'b',
-        elementCodename: 'b',
+        projectId: '4e870857-9059-4f2a-9079-618200fedff2',
+        languageCodename: 'hr',
+        itemId: '345fb42f-e243-4de0-83cd-a109799d0973',
+        elementCodename: 'comments',
       };
 
       expect(parseEditButtonDataAttributes(target)).toEqual(expected);
@@ -103,19 +113,19 @@ describe('dataAttributes.ts', () => {
     it('should work when all attributes are set on the same node', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
-        <div data-kontent-project-id="a">
-            <div data-kontent-language-codename="a">
-                <div data-kontent-item-id="a">
-                    <div data-kontent-component-id="a">
-                        <div data-kontent-element-codename="a">
-                            <div data-kontent-item-id="b">
-                                <div data-kontent-element-codename="b">
+        <div data-kontent-project-id="4e870857-9059-4f2a-9079-618200fedff2">
+            <div data-kontent-language-codename="hr">
+                <div data-kontent-item-id="e35acd87-9911-4b0b-be74-521ae9a85421">
+                    <div data-kontent-component-id="3024f2d5-effc-49b1-b4d1-0d732e49d7fc">
+                        <div data-kontent-element-codename="sections">
+                            <div data-kontent-item-id="345fb42f-e243-4de0-83cd-a109799d0973">
+                                <div data-kontent-element-codename="comments">
                                     <div
-                                      data-kontent-project-id="c"
-                                      data-kontent-language-codename="c"
-                                      data-kontent-item-id="c"
-                                      data-kontent-component-id="c"
-                                      data-kontent-element-codename="c"
+                                      data-kontent-project-id="c1321744-70e6-45d7-99e3-212bda160b23"
+                                      data-kontent-language-codename="en-us"
+                                      data-kontent-item-id="765a23d8-ac25-4f1d-9f39-7267d3d59690"
+                                      data-kontent-component-id="10a56a56-d045-4e15-be72-333d4effa21a"
+                                      data-kontent-element-codename="content"
                                     />
                                 </div>
                             </div>
@@ -127,13 +137,13 @@ describe('dataAttributes.ts', () => {
     `);
       // </editor-fold>
 
-      const target = fixture.querySelector('[data-kontent-element-codename="c"]') as HTMLElement;
+      const target = fixture.querySelector('[data-kontent-element-codename="content"]') as HTMLElement;
       const expected = {
-        projectId: 'c',
-        languageCodename: 'c',
-        itemId: 'c',
-        contentComponentId: 'c',
-        elementCodename: 'c',
+        projectId: 'c1321744-70e6-45d7-99e3-212bda160b23',
+        languageCodename: 'en-us',
+        itemId: '765a23d8-ac25-4f1d-9f39-7267d3d59690',
+        contentComponentId: '10a56a56-d045-4e15-be72-333d4effa21a',
+        elementCodename: 'content',
       };
 
       expect(parseEditButtonDataAttributes(target)).toEqual(expected);
@@ -142,21 +152,21 @@ describe('dataAttributes.ts', () => {
     it('should work when `projectId` and `languageCodename` are omitted', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
-      <div data-kontent-item-id="a">
-          <div data-kontent-component-id="a">
-              <div data-kontent-element-codename="a" />
-          </div>
+      <div data-kontent-item-id="e35acd87-9911-4b0b-be74-521ae9a85421">
+        <div data-kontent-component-id="3024f2d5-effc-49b1-b4d1-0d732e49d7fc">
+            <div data-kontent-element-codename="sections" />
+        </div>
       </div>
     `);
       // </editor-fold>
 
-      const target = fixture.querySelector('[data-kontent-element-codename="a"]') as HTMLElement;
+      const target = fixture.querySelector('[data-kontent-element-codename]') as HTMLElement;
       const expected = {
         projectId: undefined,
         languageCodename: undefined,
-        itemId: 'a',
-        contentComponentId: 'a',
-        elementCodename: 'a',
+        itemId: 'e35acd87-9911-4b0b-be74-521ae9a85421',
+        contentComponentId: '3024f2d5-effc-49b1-b4d1-0d732e49d7fc',
+        elementCodename: 'sections',
       };
 
       expect(parseEditButtonDataAttributes(target)).toEqual(expected);
@@ -167,29 +177,32 @@ describe('dataAttributes.ts', () => {
     it('should parse data attributes for fixed plus button', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
-      <div data-kontent-project-id="a" data-kontent-language-codename="a">
-        <div
-            data-kontent-item-id="parent"
-            data-kontent-element-codename="rte"
-            data-kontent-plus-button
-            data-kontent-plus-button-insert-position="end"
+        <div 
+            data-kontent-project-id="8ec75bbd-c1b9-4d10-8ac8-a7f985109301" 
+            data-kontent-language-codename="en-us"
         >
-          <div data-kontent-component-id="a">
-            <div data-kontent-element-codename="a"></div>
-          </div>
-          <div data-kontent-component-id="a">
-            <div data-kontent-element-codename="a"></div>
+          <div
+              data-kontent-item-id="99c3bcd8-f5ac-4c64-b57e-b0beb414863a"
+              data-kontent-element-codename="rte"
+              data-kontent-plus-button
+              data-kontent-plus-button-insert-position="end"
+          >
+            <div data-kontent-component-id="3ee4baf4-63ac-4a86-ad2d-8b84726e798f">
+              <div data-kontent-element-codename="cfcca1a7-04e3-4120-9c22-009a8f636fc9"></div>
+            </div>
+            <div data-kontent-component-id="ec5f1217-256e-426d-882f-22b92c538f5f">
+              <div data-kontent-element-codename="dfbcb6be-a20b-4405-afc5-8a11fa893551"></div>
+            </div>
           </div>
         </div>
-      </div>
-    `);
+      `);
       // </editor-fold>
 
       const target = fixture.querySelector('[data-kontent-plus-button]') as HTMLElement;
       const expected = {
-        projectId: 'a',
-        languageCodename: 'a',
-        itemId: 'parent',
+        projectId: '8ec75bbd-c1b9-4d10-8ac8-a7f985109301',
+        languageCodename: 'en-us',
+        itemId: '99c3bcd8-f5ac-4c64-b57e-b0beb414863a',
         elementCodename: 'rte',
         insertPosition: {
           placement: InsertPosition.End,
@@ -202,35 +215,38 @@ describe('dataAttributes.ts', () => {
     it('should parse data attributes for relative plus button', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
-      <div data-kontent-project-id="a" data-kontent-language-codename="a">
-        <div
-            data-kontent-item-id="parent"
-            data-kontent-element-codename="rte"
+        <div 
+            data-kontent-project-id="8ec75bbd-c1b9-4d10-8ac8-a7f985109301" 
+            data-kontent-language-codename="en-us"
         >
-          <div data-kontent-component-id="a">
-            <div data-kontent-element-codename="a"></div>
-          </div>
-          <div 
-            data-kontent-component-id="target" 
-            data-kontent-plus-button
-            data-kontent-plus-button-insert-position="after"
+          <div
+              data-kontent-item-id="99c3bcd8-f5ac-4c64-b57e-b0beb414863a"
+              data-kontent-element-codename="rte"
           >
-            <div data-kontent-element-codename="a"></div>
+            <div data-kontent-component-id="3ee4baf4-63ac-4a86-ad2d-8b84726e798f">
+              <div data-kontent-element-codename="cfcca1a7-04e3-4120-9c22-009a8f636fc9"></div>
+            </div>
+            <div 
+              data-kontent-component-id="b2d36acb-90af-4ce7-813a-bbcae4c2e496" 
+              data-kontent-plus-button
+              data-kontent-plus-button-insert-position="after"
+            >
+              <div data-kontent-element-codename="content"></div>
+            </div>
           </div>
-        </div>
-      </div>
-    `);
+        </div>   
+      `);
       // </editor-fold>
 
       const target = fixture.querySelector('[data-kontent-plus-button]') as HTMLElement;
       const expected = {
-        projectId: 'a',
-        languageCodename: 'a',
-        itemId: 'parent',
+        projectId: '8ec75bbd-c1b9-4d10-8ac8-a7f985109301',
+        languageCodename: 'en-us',
+        itemId: '99c3bcd8-f5ac-4c64-b57e-b0beb414863a',
         elementCodename: 'rte',
         insertPosition: {
           placement: InsertPosition.After,
-          targetId: 'target',
+          targetId: 'b2d36acb-90af-4ce7-813a-bbcae4c2e496',
         },
       };
 
@@ -242,19 +258,19 @@ describe('dataAttributes.ts', () => {
       fixture.setHtml(`
       <div>
         <div
-            data-kontent-project-id="a"
-            data-kontent-language-codename="a"
-            data-kontent-item-id="a"
-            data-kontent-component-id="parent"
-            data-kontent-element-codename="rte"
+            data-kontent-project-id="6db25ade-c2d6-43d2-ad9f-91e6cf614065"
+            data-kontent-language-codename="cs"
+            data-kontent-item-id="af1cea9a-aeed-429f-ac86-a0c78a939197"
+            data-kontent-component-id="dcc91efe-7205-4ebf-b470-e934dbc31c38"
+            data-kontent-element-codename="sections"
             data-kontent-plus-button
             data-kontent-plus-button-insert-position="end"
         >
-          <div data-kontent-component-id="a">
-            <div data-kontent-element-codename="a"></div>
+          <div data-kontent-component-id="9e7f9366-84a2-4ccf-b93a-95c08cf7fa23">
+            <div data-kontent-element-codename="content"></div>
           </div>
-          <div data-kontent-component-id="a">
-            <div data-kontent-element-codename="a"></div>
+          <div data-kontent-component-id="0b327cfd-fbef-4e71-b0de-b68003832b8c">
+            <div data-kontent-element-codename="content"></div>
           </div>
         </div>
       </div>
@@ -263,11 +279,11 @@ describe('dataAttributes.ts', () => {
 
       const target = fixture.querySelector('[data-kontent-plus-button]') as HTMLElement;
       const expected = {
-        projectId: 'a',
-        languageCodename: 'a',
-        itemId: 'a',
-        componentId: 'parent',
-        elementCodename: 'rte',
+        projectId: '6db25ade-c2d6-43d2-ad9f-91e6cf614065',
+        languageCodename: 'cs',
+        itemId: 'af1cea9a-aeed-429f-ac86-a0c78a939197',
+        componentId: 'dcc91efe-7205-4ebf-b470-e934dbc31c38',
+        elementCodename: 'sections',
         insertPosition: {
           placement: InsertPosition.End,
         },
@@ -279,40 +295,43 @@ describe('dataAttributes.ts', () => {
     it('should parse nested data attributes', () => {
       // <editor-fold desc="fixture.setHtml([HTML]);" defaultstate="collapsed">
       fixture.setHtml(`
-      <div data-kontent-project-id="a" data-kontent-language-codename="a">
-        <div
-            data-kontent-item-id="a"
-            data-kontent-component-id="parent"
-            data-kontent-element-codename="rte"
-            data-kontent-plus-button
-            data-kontent-plus-button-insert-position="end"
+        <div 
+            data-kontent-project-id="8ec75bbd-c1b9-4d10-8ac8-a7f985109301" 
+            data-kontent-language-codename="en-us"
         >
-          <div data-kontent-item-id="b">
-            <div data-kontent-component-id="b">
-              <div data-kontent-element-codename="inner-rte">
-                <div 
-                  data-kontent-item-id="c"
-                  data-kontent-plus-button
-                  data-kontent-plus-button-insert-position="before"
-                />
+          <div
+              data-kontent-item-id="8989bb18-1aee-4574-81a9-cc76234192d9"
+              data-kontent-component-id="1be9cd6e-ab95-419a-a4c6-023e540fcf58"
+              data-kontent-element-codename="content"
+              data-kontent-plus-button
+              data-kontent-plus-button-insert-position="end"
+          >
+            <div data-kontent-item-id="eb137c14-820a-48b6-9b91-19425aa76490">
+              <div data-kontent-component-id="0a197ac8-0c09-41be-bcaa-87ce9cbaf6d6">
+                <div data-kontent-element-codename="comments">
+                  <div 
+                    data-kontent-item-id="ab758fd9-4f84-4f94-962f-26752b459fe8"
+                    data-kontent-plus-button
+                    data-kontent-plus-button-insert-position="before"
+                  />
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    `);
+      `);
       // </editor-fold>
 
       const target = fixture.querySelector('[data-kontent-plus-button-insert-position="before"]') as HTMLElement;
       const expected = {
-        projectId: 'a',
-        languageCodename: 'a',
-        itemId: 'b',
-        componentId: 'b',
-        elementCodename: 'inner-rte',
+        projectId: '8ec75bbd-c1b9-4d10-8ac8-a7f985109301',
+        languageCodename: 'en-us',
+        itemId: 'eb137c14-820a-48b6-9b91-19425aa76490',
+        componentId: '0a197ac8-0c09-41be-bcaa-87ce9cbaf6d6',
+        elementCodename: 'comments',
         insertPosition: {
           placement: InsertPosition.Before,
-          targetId: 'c',
+          targetId: 'ab758fd9-4f84-4f94-962f-26752b459fe8',
         },
       };
 


### PR DESCRIPTION
- Data attributes parser now accepts pattern as a first argument.
- Separate patterns are used to parse data attributes for edit buttons and plus buttons.
- Tests for new data attributes parser.