### PR TITLE
KCL-7095 Unify tooltips between KK and SDK

### DIFF
--- a/src/web-components/KSLAddButtonElement.ts
+++ b/src/web-components/KSLAddButtonElement.ts
@@ -19,6 +19,7 @@ import { AsyncCustomEvent } from '../utils/events';
 import { Logger } from '../lib/Logger';
 
 const ContentIsPublishedTooltip = 'Content is published';
+const DefaultTooltipMessage = 'Insert...';
 
 enum PopoverButtonId {
   CreateComponent = 'create-component',
@@ -68,7 +69,7 @@ const getPopoverHtml = ({ elementType, isParentPublished }: IAddButtonPermission
     class="ksl-add-button__popover-button"
     type="${ButtonType.Quinary}"
     tooltip-position="${ElementPositionOffset.Top}"
-    tooltip-message="${isParentPublished ? ContentIsPublishedTooltip : 'Add existing linked item'}"
+    tooltip-message="${isParentPublished ? ContentIsPublishedTooltip : 'Insert existing item'}"
     ${isParentPublished && 'disabled'}
   >
     <ksl-icon icon-name="${IconName.Puzzle}"/>
@@ -78,7 +79,7 @@ const getPopoverHtml = ({ elementType, isParentPublished }: IAddButtonPermission
     class="ksl-add-button__popover-button"
     type="${ButtonType.Quinary}"
     tooltip-position="${ElementPositionOffset.Top}"
-    tooltip-message="${isParentPublished ? ContentIsPublishedTooltip : 'Add new linked item'}"
+    tooltip-message="${isParentPublished ? ContentIsPublishedTooltip : 'Create new item'}"
     ${isParentPublished && 'disabled'}
     ${elementType !== AddButtonElementType.LinkedItems && 'hidden'}
   >
@@ -89,7 +90,7 @@ const getPopoverHtml = ({ elementType, isParentPublished }: IAddButtonPermission
     class="ksl-add-button__popover-button"
     type="${ButtonType.Quinary}"
     tooltip-position="${ElementPositionOffset.Top}"
-    tooltip-message="${isParentPublished ? ContentIsPublishedTooltip : 'Add component'}"
+    tooltip-message="${isParentPublished ? ContentIsPublishedTooltip : 'Insert new component'}"
     ${isParentPublished && 'disabled'}
     ${elementType !== AddButtonElementType.RichText && 'hidden'}
   >
@@ -147,7 +148,7 @@ export class KSLAddButtonElement extends KSLPositionedElement {
 
     window.addEventListener('click', this.handleClickOutside, { capture: true });
     this.buttonRef.addEventListener('click', this.handleClick);
-    this.buttonRef.tooltipMessage = 'Add component/item';
+    this.buttonRef.tooltipMessage = DefaultTooltipMessage;
   }
 
   public disconnectedCallback(): void {
@@ -243,7 +244,7 @@ export class KSLAddButtonElement extends KSLPositionedElement {
       } else {
         this.buttonRef.loading = false;
         this.buttonRef.disabled = false;
-        this.buttonRef.tooltipMessage = 'Add component/item';
+        this.buttonRef.tooltipMessage = DefaultTooltipMessage;
 
         this.showPopover(response);
       }

--- a/src/web-components/KSLHighlightElement.ts
+++ b/src/web-components/KSLHighlightElement.ts
@@ -93,7 +93,7 @@ const templateHTML = `
       class="ksl-highlight__toolbar-button"
       type="${ButtonType.Quinary}"
       tooltip-position="${ElementPositionOffset.BottomEnd}"
-      tooltip-message="Edit">
+    >
       <ksl-icon icon-name="${IconName.Edit}" />
     </ksl-button>
   </div>
@@ -129,6 +129,22 @@ export class KSLHighlightElement extends KSLPositionedElement {
     return createTemplateForCustomElement(templateHTML);
   }
 
+  private static getEditButtonTooltip(type: HighlightType): string {
+    switch (type) {
+      case HighlightType.Element:
+        return 'Edit element';
+
+      case HighlightType.ContentComponent:
+        return 'Edit component';
+
+      case HighlightType.ContentItem:
+        return 'Edit item';
+
+      default:
+        return 'Edit';
+    }
+  }
+
   public connectedCallback(): void {
     super.connectedCallback();
 
@@ -147,7 +163,9 @@ export class KSLHighlightElement extends KSLPositionedElement {
 
     super.attachTo(node);
 
-    this.hidden = this.type === HighlightType.None;
+    const type = this.type;
+    this.hidden = type === HighlightType.None;
+    this.editButtonRef.tooltipMessage = KSLHighlightElement.getEditButtonTooltip(type);
 
     if (this.targetRef) {
       this.targetRef.addEventListener('mousemove', this.handleTargetNodeMouseEnter);


### PR DESCRIPTION
- Change default add button tooltip to ‘Insert…’.
- Change Add component button tooltip to ‘Insert new component’.
- Change Add existing item button tooltip to ‘Insert existing item’.
- Change Add new item button tooltip to ‘Create new item’.
- Edit buttons now have different tooltips based on their type (element, item, component).

Tooltips related to permissions have already been changed here - https://github.com/Kentico/kontent-smart-link/pull/45/files#diff-94998b23bc0ace86dd066268c297ca98e5db183f39494b1cba5caa3450b7cc0aR235 